### PR TITLE
⚡ Optimize storage reads and batch aggregator calls in views

### DIFF
--- a/controller/src/cache/mod.rs
+++ b/controller/src/cache/mod.rs
@@ -1,4 +1,5 @@
-use common_structs::{AssetConfig, MarketIndex, OracleProvider, PriceFeedShort};
+use common_constants::USD_TICKER;
+use common_structs::{AssetConfig, MarketIndex, OracleProvider, PriceFeedShort, PricingMethod};
 
 multiversx_sc::imports!();
 multiversx_sc::derive_imports!();
@@ -26,6 +27,13 @@ where
     pub flash_loan_ongoing: bool,
     pub safe_price_view: ManagedAddress<C::Api>,
     pub current_timestamp: u64,
+
+    pub price_aggregator_paused: bool,
+    pub aggregator_feeds: ManagedMapEncoded<
+        C::Api,
+        ManagedBuffer<C::Api>,
+        crate::proxy_price_aggregator::PriceFeed<C::Api>,
+    >,
 }
 
 impl<'a, C> Cache<'a, C>
@@ -37,33 +45,47 @@ where
     /// Returns cache with empty collections and current blockchain timestamp.
     pub fn new(sc_ref: &'a C) -> Self {
         let price_aggregator = sc_ref.price_aggregator_address().get();
+        let price_aggregator_paused = if !price_aggregator.is_zero() {
+            sc_ref
+                .price_aggregator_paused_state(price_aggregator.clone())
+                .get()
+        } else {
+            false
+        };
+
         let egld_token_id = EgldOrEsdtTokenIdentifier::egld();
         let egld_provider = sc_ref.token_oracle(&egld_token_id).get();
         let mut asset_oracles = ManagedMapEncoded::new();
         asset_oracles.put(&egld_token_id, &egld_provider);
-        let egld_price_feed = sc_ref.aggregator_price_feed(
-            egld_token_id.clone().into_name(),
-            &price_aggregator,
-            egld_provider.max_price_stale_seconds,
-            false,
-        );
-        let egld_usd_price_wad = sc_ref.to_decimal_wad(egld_price_feed.price);
 
-        Cache {
+        let mut cache = Cache {
             sc_ref,
             prices_cache: ManagedMapEncoded::new(),
             asset_configs: ManagedMapEncoded::new(),
             asset_pools: ManagedMapEncoded::new(),
             asset_oracles,
             market_indexes: ManagedMapEncoded::new(),
-            egld_usd_price_wad,
+            egld_usd_price_wad: ManagedDecimal::zero(),
             price_aggregator_sc: price_aggregator,
             egld_ticker: egld_token_id.into_name(),
             allow_unsafe_price: true,
             flash_loan_ongoing: sc_ref.flash_loan_ongoing().get(),
             safe_price_view: sc_ref.safe_price_view().get(),
             current_timestamp: sc_ref.blockchain().get_block_timestamp_ms(),
-        }
+            price_aggregator_paused,
+            aggregator_feeds: ManagedMapEncoded::new(),
+        };
+
+        let egld_price_feed = sc_ref.aggregator_price_feed(
+            cache.egld_ticker.clone(),
+            &cache.price_aggregator_sc,
+            egld_provider.max_price_stale_seconds,
+            false,
+            &mut cache,
+        );
+        cache.egld_usd_price_wad = sc_ref.to_decimal_wad(egld_price_feed.price);
+
+        cache
     }
 
     /// Clears price cache to force fresh price fetches after swaps.
@@ -158,5 +180,40 @@ where
         self.asset_pools.put(token_id, &address);
 
         address
+    }
+
+    /// Pre-fetches oracle configurations and aggregator prices for a list of assets.
+    /// Reduces gas costs by batching cross-contract calls and caching results.
+    pub fn pre_fetch_assets_data(
+        &mut self,
+        assets: &ManagedVec<C::Api, EgldOrEsdtTokenIdentifier<C::Api>>,
+    ) {
+        let mut pairs = MultiValueEncoded::new();
+        for asset in assets {
+            let oracle_configs = self.cached_oracle(&asset);
+            if oracle_configs.pricing_method == PricingMethod::Aggregator
+                || oracle_configs.pricing_method == PricingMethod::Mix
+            {
+                pairs.push(crate::proxy_price_aggregator::TokenPair {
+                    from: self.sc_ref.token_ticker(&asset, self),
+                    to: ManagedBuffer::new_from_bytes(USD_TICKER),
+                });
+            }
+        }
+
+        if !pairs.is_empty() && !self.price_aggregator_sc.is_zero() {
+            let results: MultiValueEncoded<crate::proxy_price_aggregator::PriceFeed<C::Api>> = self
+                .sc_ref
+                .tx()
+                .to(&self.price_aggregator_sc)
+                .typed(crate::proxy_price_aggregator::PriceAggregatorProxy)
+                .latest_round_data(pairs)
+                .returns(ReturnsResult)
+                .sync_call_readonly();
+
+            for result in results {
+                self.aggregator_feeds.put(&result.from, &result);
+            }
+        }
     }
 }

--- a/controller/src/oracle/mod.rs
+++ b/controller/src/oracle/mod.rs
@@ -207,10 +207,7 @@ pub trait OracleModule:
             return cache.prices_cache.get(token_id);
         }
 
-        let oracle_data = self.token_oracle(token_id);
-        require!(!oracle_data.is_empty(), ERROR_ORACLE_TOKEN_NOT_FOUND);
-
-        let data = oracle_data.get();
+        let data = cache.cached_oracle(token_id);
 
         let feed = if data.oracle_type == OracleType::None {
             PriceFeedShort {
@@ -872,6 +869,7 @@ pub trait OracleModule:
             &cache.price_aggregator_sc,
             max_seconds_stale,
             cache.allow_unsafe_price,
+            cache,
         );
         let token_usd_price_wad = self.to_decimal_wad(feed.price);
         self.rescale_half_up(
@@ -1153,17 +1151,22 @@ pub trait OracleModule:
         price_aggregator_sc: &ManagedAddress,
         max_seconds_stale: u64,
         allow_unsafe_price: bool,
+        cache: &mut Cache<Self>,
     ) -> PriceFeed<Self::Api> {
         require!(
             !price_aggregator_sc.is_zero(),
             ERROR_PRICE_AGGREGATOR_NOT_SET
         );
-        require!(
-            !self
-                .price_aggregator_paused_state(price_aggregator_sc.clone())
-                .get(),
-            PAUSED_ERROR
-        );
+        require!(!cache.price_aggregator_paused, PAUSED_ERROR);
+
+        if cache.aggregator_feeds.contains(&from_ticker) {
+            let feed = cache.aggregator_feeds.get(&from_ticker);
+            if self.blockchain().get_block_timestamp() - feed.timestamp < max_seconds_stale
+                || allow_unsafe_price
+            {
+                return feed;
+            }
+        }
 
         let token_pair = TokenPair {
             from: from_ticker,
@@ -1281,9 +1284,7 @@ pub trait OracleModule:
             return (None, None, self.wad(), true, true);
         }
 
-        let oracle_data = self.token_oracle(token_id);
-        require!(!oracle_data.is_empty(), ERROR_ORACLE_TOKEN_NOT_FOUND);
-        let configs = oracle_data.get();
+        let configs = cache.cached_oracle(token_id);
 
         match configs.oracle_type {
             OracleType::Lp => {

--- a/controller/src/views.rs
+++ b/controller/src/views.rs
@@ -1,6 +1,7 @@
 use common_constants::{BPS_PRECISION, WAD_PRECISION};
 use common_structs::{
     AccountPositionType, AssetExtendedConfigView, LiquidationEstimate, MarketIndexView,
+    PricingMethod,
 };
 
 use crate::{cache::Cache, helpers, oracle, positions, storage, utils, validation};
@@ -45,6 +46,24 @@ pub trait ViewsModule:
     ) -> LiquidationEstimate<Self::Api> {
         let mut cache = Cache::new(self);
         self.require_active_account(account_nonce);
+
+        let mut assets = ManagedVec::new();
+        for pos in self
+            .positions(account_nonce, AccountPositionType::Deposit)
+            .values()
+        {
+            assets.push(pos.asset_id.clone());
+        }
+        for pos in self
+            .positions(account_nonce, AccountPositionType::Borrow)
+            .values()
+        {
+            assets.push(pos.asset_id.clone());
+        }
+        for payment in debt_payments {
+            assets.push(payment.token_identifier.clone());
+        }
+        cache.pre_fetch_assets_data(&assets);
 
         let (collaterals, _, refunds, max_egld_payment_ray, bonus_rate_ray) =
             self.execute_liquidation(account_nonce, debt_payments, &mut cache);
@@ -92,11 +111,14 @@ pub trait ViewsModule:
         assets: MultiValueEncoded<EgldOrEsdtTokenIdentifier>,
     ) -> ManagedVec<MarketIndexView<Self::Api>> {
         let mut cache = Cache::new(self);
+        let assets_vec = assets.to_vec();
+        cache.pre_fetch_assets_data(&assets_vec);
+
         // Views allow unsafe prices to show monitoring data even when protocol would block operations
         // This matches the behavior of operational functions - cache defaults to allow_unsafe_price = true
         let mut markets = ManagedVec::new();
 
-        for asset in assets {
+        for asset in assets_vec {
             let indexes = self.update_asset_index(&asset, &mut cache, true);
 
             // Get price components including safe and aggregator prices
@@ -148,9 +170,12 @@ pub trait ViewsModule:
         assets: MultiValueEncoded<EgldOrEsdtTokenIdentifier>,
     ) -> ManagedVec<AssetExtendedConfigView<Self::Api>> {
         let mut cache = Cache::new(self);
+        let assets_vec = assets.to_vec();
+        cache.pre_fetch_assets_data(&assets_vec);
+
         let mut markets = ManagedVec::new();
-        for asset in assets {
-            let pool_address = self.pools_map(&asset).get();
+        for asset in assets_vec {
+            let pool_address = cache.cached_pool_address(&asset);
             let feed = self.token_price(&asset, &mut cache);
             let usd = self.egld_usd_value(&feed.price_wad, &cache.egld_usd_price_wad);
 
@@ -189,15 +214,27 @@ pub trait ViewsModule:
     #[view(getHealthFactor)]
     fn health_factor(&self, account_nonce: u64) -> ManagedDecimal<Self::Api, NumDecimals> {
         let mut cache = Cache::new(self);
-        let deposit_positions = self.positions(account_nonce, AccountPositionType::Deposit);
+        let deposit_positions: ManagedVec<AccountPosition<Self::Api>> = self
+            .positions(account_nonce, AccountPositionType::Deposit)
+            .values()
+            .collect();
 
-        let (weighted_collateral, _, _) =
-            self.calculate_collateral_values(&deposit_positions.values().collect(), &mut cache);
-
-        let borrow_positions = self
+        let borrow_positions: ManagedVec<AccountPosition<Self::Api>> = self
             .positions(account_nonce, AccountPositionType::Borrow)
             .values()
             .collect();
+
+        let mut assets = ManagedVec::new();
+        for pos in &deposit_positions {
+            assets.push(pos.asset_id.clone());
+        }
+        for pos in &borrow_positions {
+            assets.push(pos.asset_id.clone());
+        }
+        cache.pre_fetch_assets_data(&assets);
+
+        let (weighted_collateral, _, _) =
+            self.calculate_collateral_values(&deposit_positions, &mut cache);
 
         let total_borrow_ray = self.calculate_total_borrow_in_egld(&borrow_positions, &mut cache);
 
@@ -273,10 +310,17 @@ pub trait ViewsModule:
     #[view(getTotalBorrowInEgld)]
     fn total_borrow_in_egld(&self, account_nonce: u64) -> ManagedDecimal<Self::Api, NumDecimals> {
         let mut cache = Cache::new(self);
-        let borrow_positions = self
+        let borrow_positions: ManagedVec<AccountPosition<Self::Api>> = self
             .positions(account_nonce, AccountPositionType::Borrow)
             .values()
             .collect();
+
+        let mut assets = ManagedVec::new();
+        for pos in &borrow_positions {
+            assets.push(pos.asset_id.clone());
+        }
+        cache.pre_fetch_assets_data(&assets);
+
         let total_borrow_ray = self.calculate_total_borrow_in_egld(&borrow_positions, &mut cache);
 
         self.rescale_half_up(&total_borrow_ray, WAD_PRECISION)
@@ -295,12 +339,20 @@ pub trait ViewsModule:
         &self,
         account_nonce: u64,
     ) -> ManagedDecimal<Self::Api, NumDecimals> {
-        let deposit_positions = self.positions(account_nonce, AccountPositionType::Deposit);
-
         let mut cache = Cache::new(self);
+        let deposit_positions: ManagedVec<AccountPosition<Self::Api>> = self
+            .positions(account_nonce, AccountPositionType::Deposit)
+            .values()
+            .collect();
+
+        let mut assets = ManagedVec::new();
+        for pos in &deposit_positions {
+            assets.push(pos.asset_id.clone());
+        }
+        cache.pre_fetch_assets_data(&assets);
 
         deposit_positions
-            .values()
+            .iter()
             .fold(self.wad_zero(), |accumulator, dp| {
                 let feed = self.token_price(&dp.asset_id, &mut cache);
                 let amount = self.total_amount_ray(&dp, &mut cache);
@@ -321,12 +373,20 @@ pub trait ViewsModule:
         &self,
         account_nonce: u64,
     ) -> ManagedDecimal<Self::Api, NumDecimals> {
-        let deposit_positions = self.positions(account_nonce, AccountPositionType::Deposit);
-
         let mut cache = Cache::new(self);
+        let deposit_positions: ManagedVec<AccountPosition<Self::Api>> = self
+            .positions(account_nonce, AccountPositionType::Deposit)
+            .values()
+            .collect();
+
+        let mut assets = ManagedVec::new();
+        for pos in &deposit_positions {
+            assets.push(pos.asset_id.clone());
+        }
+        cache.pre_fetch_assets_data(&assets);
 
         let (weighted_collateral, _, _) =
-            self.calculate_collateral_values(&deposit_positions.values().collect(), &mut cache);
+            self.calculate_collateral_values(&deposit_positions, &mut cache);
 
         self.rescale_half_up(&weighted_collateral, WAD_PRECISION)
     }
@@ -341,12 +401,20 @@ pub trait ViewsModule:
     /// - LTV-weighted collateral in EGLD as a `ManagedDecimal`.
     #[view(getLtvCollateralInEgld)]
     fn ltv_collateral_in_egld(&self, account_nonce: u64) -> ManagedDecimal<Self::Api, NumDecimals> {
-        let deposit_positions = self.positions(account_nonce, AccountPositionType::Deposit);
-
         let mut cache = Cache::new(self);
+        let deposit_positions: ManagedVec<AccountPosition<Self::Api>> = self
+            .positions(account_nonce, AccountPositionType::Deposit)
+            .values()
+            .collect();
+
+        let mut assets = ManagedVec::new();
+        for pos in &deposit_positions {
+            assets.push(pos.asset_id.clone());
+        }
+        cache.pre_fetch_assets_data(&assets);
 
         let (_, _, ltv_collateral) =
-            self.calculate_collateral_values(&deposit_positions.values().collect(), &mut cache);
+            self.calculate_collateral_values(&deposit_positions, &mut cache);
 
         self.rescale_half_up(&ltv_collateral, WAD_PRECISION)
     }


### PR DESCRIPTION
💡 **What:**
- Introduced a batching and caching mechanism for asset data retrieval.
- Added `pre_fetch_assets_data` to the `Cache` struct which performs a single cross-contract call (`latestRoundData`) to the price aggregator for all required assets.
- Cached the `price_aggregator_paused` state and individual `PriceFeed` results to avoid redundant storage reads and calls.
- Applied pre-fetching to all major view functions: `getAllMarkets`, `getAllMarketIndexes`, `getHealthFactor`, `getTotalBorrowInEgld`, `getTotalCollateralInEgld`, `getLiquidationCollateralAvailable`, `getLtvCollateralInEgld`, and `liquidationEstimations`.

🎯 **Why:**
Previously, iterating over $N$ assets in a view caused $2N$ remote storage reads/calls to the price aggregator (one for paused status, one for price). For a position with many assets, this caused significant performance degradation and potentially gas limit issues.

📊 **Measured Improvement:**
- Reduced storage reads for aggregator status from $O(N)$ to $O(1)$.
- Reduced cross-contract calls for prices from $O(N)$ to $O(1)$.
- Individual storage reads for pool addresses and oracle providers were consolidated using the `Cache` mechanism.
- Although environmental timeouts made numerical gas measurements impractical, the reduction of remote I/O overhead provides a clear and necessary performance boost for multi-asset positions.

---
*PR created automatically by Jules for task [2961126875210726225](https://jules.google.com/task/2961126875210726225) started by @mihaieremia*